### PR TITLE
Make elasticsearch6 image the on in the imanage registry, so it works…

### DIFF
--- a/es6-multinode/docker-compose.yml
+++ b/es6-multinode/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     extends:
       file: "common.yml"
       service: "common"
-    image: "elasticsearch6"
+    image: "registry.imanage.com/imanagelabs/elasticsearch6"
     mem_limit: "1024m"
     restart: on-failure:12
     volumes:


### PR DESCRIPTION
… after clearing CR

When I completely cleared out and restarted my CR, docker-compose wouldn't work because image name was "elasticsearch6" and of course that wasn't in my local image list any longer. If there is no need to specify a local image "elasticsearch6", let's change it to "registry.imanage.com/imanagelabs/elasticsearch6"